### PR TITLE
タスク作成機能実装

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers;
 // モデルの読み込み
 use App\Folder;
 use App\Task;
-
 use Illuminate\Http\Request;
+use App\Http\Requests\CreateTask;
 
 class TaskController extends Controller
 {
@@ -36,18 +36,23 @@ class TaskController extends Controller
         ]);
     }
 
-    // // コントローラーメソッドが呼び出されるときに Laravel がリクエストの情報を Request クラスのインスタンス $request に詰めて引数として渡す
-    // public function create(CreateFolder $request)
-    // {
-    //     // フォルダモデルの新規インスタンスを作成
-    //     $folder = new Folder();
-    //     // $folderインスタンスのタイトルに$requestインスタンスのタイトル入力値を代入
-    //     $folder->title = $request->title;
-    //     // インスタンスの情報をDBに保存
-    //     $folder->save();
+    // コントローラーメソッドが呼び出されるときに Laravel がリクエストの情報を Request クラスのインスタンス $request に詰めて引数として渡す
+    public function create(int $id, CreateTask $request)
+    {
+        // idを基に紐づいたフォルダを特定
+        $current_folder = Folder::find($id);
 
-    //     return redirect()->route('tasks.index', [
-    //         'id' => $folder->id,
-    //     ]);
-    // }
+        // 新しいタスクインスタンス作成
+        $task = new Task();
+        // $taskインスタンスのタイトル/期限にに$requestインスタンスの各プロパティを代入
+        $task->title = $request->title;
+        $task->due_date = $request->due_date;
+
+        // 設定したリレーションを基にフォルダに紐づいたタスクとして保存
+        $current_folder->tasks()->save($task);
+
+        return redirect()->route('tasks.index', [
+            'id' => $current_folder->id,
+        ]);
+    }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -28,4 +28,26 @@ class TaskController extends Controller
             'tasks' => $tasks,
         ]);
     }
+
+    public function showCreateForm(int $id)
+    {
+        return view('tasks/create',[
+            'folder_id' => $id
+        ]);
+    }
+
+    // // コントローラーメソッドが呼び出されるときに Laravel がリクエストの情報を Request クラスのインスタンス $request に詰めて引数として渡す
+    // public function create(CreateFolder $request)
+    // {
+    //     // フォルダモデルの新規インスタンスを作成
+    //     $folder = new Folder();
+    //     // $folderインスタンスのタイトルに$requestインスタンスのタイトル入力値を代入
+    //     $folder->title = $request->title;
+    //     // インスタンスの情報をDBに保存
+    //     $folder->save();
+
+    //     return redirect()->route('tasks.index', [
+    //         'id' => $folder->id,
+    //     ]);
+    // }
 }

--- a/app/Http/Requests/CreateTask.php
+++ b/app/Http/Requests/CreateTask.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateTask extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required|max:100',
+            'due_date' => 'required|date|after_or_equal:today',
+        ];
+    }
+
+    public function attributes()
+    {
+        return [
+            'title' => 'タイトル',
+            'due_date' => '期限日',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            // キーでメッセージが表示されるべきルールを指定する。
+            // ドット区切りで左側が項目、右側がルールを意味する。
+            'due_date.after_or_equal' => ':attribute には今日以降の数字を入れてください'
+        ];
+    }
+}

--- a/app/Http/Requests/CreateTask.php
+++ b/app/Http/Requests/CreateTask.php
@@ -42,7 +42,7 @@ class CreateTask extends FormRequest
         return [
             // キーでメッセージが表示されるべきルールを指定する。
             // ドット区切りで左側が項目、右側がルールを意味する。
-            'due_date.after_or_equal' => ':attribute には今日以降の数字を入れてください'
+            'due_date.after_or_equal' => ':attribute には今日以降の日付を入力してください。'
         ];
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -33,6 +33,12 @@ return [
 
     'connections' => [
 
+        'sqlite_testing' => [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ],
+
         'sqlite' => [
             'driver' => 'sqlite',
             'database' => env('DB_DATABASE', database_path('database.sqlite')),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite_testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="MAIL_DRIVER" value="array"/>

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -31,7 +31,7 @@ return [
     ],
     'boolean' => 'The :attribute field must be true or false.',
     'confirmed' => 'The :attribute confirmation does not match.',
-    'date' => ':attribute には日付を入力してください',
+    'date' => ':attribute には日付を入力してください。',
     'date_equals' => 'The :attribute must be a date equal to :date.',
     'date_format' => 'The :attribute does not match the format :format.',
     'different' => 'The :attribute and :other must be different.',

--- a/resources/lang/jp/validation.php
+++ b/resources/lang/jp/validation.php
@@ -31,7 +31,7 @@ return [
     ],
     'boolean' => 'The :attribute field must be true or false.',
     'confirmed' => 'The :attribute confirmation does not match.',
-    'date' => 'The :attribute is not a valid date.',
+    'date' => ':attribute には日付を入力してください',
     'date_equals' => 'The :attribute must be a date equal to :date.',
     'date_format' => 'The :attribute does not match the format :format.',
     'different' => 'The :attribute and :other must be different.',

--- a/resources/views/folders/create.blade.php
+++ b/resources/views/folders/create.blade.php
@@ -1,53 +1,36 @@
-<!DOCTYPE html>
-<html lang="ja">
+@extends('layout')
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ToDo App</title>
-  <link rel="stylesheet" href="/public/css/styles.css">
-</head>
-
-<body>
-  <header>
-    <nav class="my-navbar">
-      <a class="my-navbar-brand" href="/">ToDo App</a>
-    </nav>
-  </header>
-  <main>
-    <div class="container">
-      <div class="row">
-        <div class="col col-md-ofset-3 col-md-6">
-          <nav class="panel panel-default">
-            <div class="panel-heading">フォルダを追加する</div>
-            <div class="panel-body">
-              @if($errors->any())
-              <div class="alert alert-danger">
-                <ul>
-                  @foreach($errors->all() as $message)
-                  <li>
-                    {{ $message }}
-                  </li>
-                  @endforeach
-                </ul>
-              </div>
-              @endif
-              <form action="{{ route('folders.create') }}" method="post">
-                @csrf
-                <div class="form-group">
-                  <label for="title">フォルダ名</label>
-                  <input type="text" class="form control" name="title" id="title" value="{{ old('title') }}" />
-                </div>
-                <div class="text-right">
-                  <button type="submit" class="btn btn-primary">送信</button>
-                </div>
-              </form>
+@section('content')
+<div class="container">
+  <div class="row">
+    <div class="col col-md-ofset-3 col-md-6">
+      <nav class="panel panel-default">
+        <div class="panel-heading">フォルダを追加する</div>
+        <div class="panel-body">
+          @if($errors->any())
+          <div class="alert alert-danger">
+            <ul>
+              @foreach($errors->all() as $message)
+              <li>
+                {{ $message }}
+              </li>
+              @endforeach
+            </ul>
+          </div>
+          @endif
+          <form action="{{ route('folders.create') }}" method="post">
+            @csrf
+            <div class="form-group">
+              <label for="title">フォルダ名</label>
+              <input type="text" class="form control" name="title" id="title" value="{{ old('title') }}" />
             </div>
-          </nav>
+            <div class="text-right">
+              <button type="submit" class="btn btn-primary">送信</button>
+            </div>
+          </form>
         </div>
-      </div>
+      </nav>
     </div>
-  </main>
-</body>
-
-</html>
+  </div>
+</div>
+@endsection

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ToDo App</title>
+  @yield('styles')
+  <link rel="stylesheet" href="/public/css/styles.css">
+</head>
+
+<body>
+  <header>
+    <nav class="my-navbar">
+      <a class="my-navbar-brand" href="/">ToDo App</a>
+    </nav>
+  </header>
+  <main>
+    @yield('content')
+  </main>
+  @yield('scripts')
+</body>
+
+</html>

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,65 +1,53 @@
-<!DOCTYPE html>
-<html lang="ja">
+@extends('layout')
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ToDo App</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-  <link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
-  <link rel="stylesheet" href="/public/css/styles.css">
-</head>
+@section('styles')
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+@endsection
 
-<body>
-  <header>
-    <nav class="my-navbar">
-      <a class="my-navbar-brand" href="/">ToDo App</a>
-    </nav>
-  </header>
-  <main>
-    <div class="container">
-      <div class="row">
-        <div class="col col-md-offset-3 col-md-6">
-          <nav class="panel panel-default">
-            <div class="panel-heading">タスクを追加する</div>
-            <div class="panel-body">
-              @if($errors->any())
-              <div class="alert alert-danger">
-                @foreach($errors->all() as $message)
-                <p>{{ $message }}</p>
-                @endforeach
-              </div>
-              @endif
-              <form action="{{ route('tasks.create', ['id' => $folder_id]) }}" method="POST">
-                @csrf
-                <div class="form-group">
-                  <label for="title">タイトル</label>
-                  <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
-                </div>
-                <div class="form-group">
-                  <label for="due_date">期限</label>
-                  <input type="text" class="form-control" name="due_date" id="due_date" value="{{ old('due_date') }}" />
-                </div>
-                <div class="text-right">
-                  <button type="submit" class="btn btn-primary">送信</button>
-                </div>
-              </form>
+@section('content')
+<div class="container">
+  <div class="row">
+    <div class="col col-md-offset-3 col-md-6">
+      <nav class="panel panel-default">
+        <div class="panel-heading">タスクを追加する</div>
+        <div class="panel-body">
+          @if($errors->any())
+          <div class="alert alert-danger">
+            @foreach($errors->all() as $message)
+            <p>{{ $message }}</p>
+            @endforeach
+          </div>
+          @endif
+          <form action="{{ route('tasks.create', ['id' => $folder_id]) }}" method="POST">
+            @csrf
+            <div class="form-group">
+              <label for="title">タイトル</label>
+              <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
             </div>
-          </nav>
+            <div class="form-group">
+              <label for="due_date">期限</label>
+              <input type="text" class="form-control" name="due_date" id="due_date" value="{{ old('due_date') }}" />
+            </div>
+            <div class="text-right">
+              <button type="submit" class="btn btn-primary">送信</button>
+            </div>
+          </form>
         </div>
-      </div>
+      </nav>
     </div>
-  </main>
+  </div>
+</div>
+@endsection
 
-  <script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
-  <script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
-  <script>
-    flatpickr(document.getElementById('due_date'), {
-      locale: 'ja',
-      dateFormat: "Y/m/d",
-      minDate: new Date()
-    });
-  </script>
-</body>
-
-</html>
+@section('scripts')
+<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
+<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
+<script>
+  flatpickr(document.getElementById('due_date'), {
+    locale: 'ja',
+    dateFormat: "Y/m/d",
+    minDate: new Date()
+  });
+</script>
+@endsection

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ToDo App</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+  <link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+  <link rel="stylesheet" href="/public/css/styles.css">
+</head>
+
+<body>
+  <header>
+    <nav class="my-navbar">
+      <a class="my-navbar-brand" href="/">ToDo App</a>
+    </nav>
+  </header>
+  <main>
+    <div class="container">
+      <div class="row">
+        <div class="col col-md-offset-3 col-md-6">
+          <nav class="panel panel-default">
+            <div class="panel-heading">タスクを追加する</div>
+            <div class="panel-body">
+              @if($errors->any())
+              <div class="alert alert-danger">
+                @foreach($errors->all() as $message)
+                <p>{{ $message }}</p>
+                @endforeach
+              </div>
+              @endif
+              <form action="{{ route('tasks.create', ['id' => $folder_id]) }}" method="POST">
+                @csrf
+                <div class="form-group">
+                  <label for="title">タイトル</label>
+                  <input type="text" class="form-control" name="title" id="title" value="{{ old('title') }}" />
+                </div>
+                <div class="form-group">
+                  <label for="due_date">期限</label>
+                  <input type="text" class="form-control" name="due_date" id="due_date" value="{{ old('due_date') }}" />
+                </div>
+                <div class="text-right">
+                  <button type="submit" class="btn btn-primary">送信</button>
+                </div>
+              </form>
+            </div>
+          </nav>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
+  <script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
+  <script>
+    flatpickr(document.getElementById('due_date'), {
+      locale: 'ja',
+      dateFormat: "Y/m/d",
+      minDate: new Date()
+    });
+  </script>
+</body>
+
+</html>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -1,83 +1,69 @@
-<!DOCTYPE html>
-<html lang="ja">
+@extends('layout')
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ToDo App</title>
-  <link rel="stylesheet" href="/public/css/styles.css">
-</head>
-
-<body>
-  <header>
-    <nav class="my-navbar">
-      <a class="my-navbar-brand" href="/">ToDo App</a>
-    </nav>
-  </header>
-  <main>
-    <div class="container">
-      <div class="row">
-        <div class="col col-md-4">
-          <nav class="panel panel-default">
-            <div class="panel-heading">フォルダ</div>
-            <div class="panel-body">
-              <a href="{{ route('folders.create') }}" class="btn btn-default btn-block">
-                フォルダを追加する
-              </a>
-            </div>
-            <div class="list-group">
-              @foreach($folders as $folder)
-              <a href="{{ route('tasks.index', ['id' => $folder->id]) }}" class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}">
-                {{ $folder->title }}
-              </a>
-
-              @endforeach
-            </div>
-          </nav>
-        </div>
-        <div class="column col-md-8">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              タスク
-            </div>
-            <div class="panel-body">
-              <div class="text-right">
-                <a href="#" class="btn btn-default btn-block">
-                  タスクを追加する
-                </a>
-              </div>
-            </div>
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>タイトル</th>
-                  <th>状態</th>
-                  <th>期限</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                @foreach ($tasks as $task)
-                <tr>
-                  <td>
-                    {{$task->title}}
-                  </td>
-                  <td>
-                    <span class="label {{$task->status_class}}">{{$task->status_label}}</span>
-                  </td>
-                  <td>
-                    {{$task->formatted_due_date}}
-                  </td>
-                  <td>
-                    <a href="#">編集</a>
-                  </td>
-                </tr> @endforeach </tbody>
-            </table>
+@section('content')
+  <div class="container">
+    <div class="row">
+      <div class="col col-md-4">
+        <nav class="panel panel-default">
+          <div class="panel-heading">フォルダ</div>
+          <div class="panel-body">
+            <a href="{{ route('folders.create') }}" class="btn btn-default btn-block">
+              フォルダを追加する
+            </a>
           </div>
+          <div class="list-group">
+            @foreach($folders as $folder)
+            <a href="{{ route('tasks.index', ['id' => $folder->id]) }}" class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}">
+              {{ $folder->title }}
+            </a>
+
+            @endforeach
+          </div>
+        </nav>
+      </div>
+      <div class="column col-md-8">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            タスク
+          </div>
+          <div class="panel-body">
+            <div class="text-right">
+              <a href="#" class="btn btn-default btn-block">
+                タスクを追加する
+              </a>
+            </div>
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>タイトル</th>
+                <th>状態</th>
+                <th>期限</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              @foreach ($tasks as $task)
+              <tr>
+                <td>
+                  {{$task->title}}
+                </td>
+                <td>
+                  <span class="label {{$task->status_class}}">{{$task->status_label}}</span>
+                </td>
+                <td>
+                  {{$task->formatted_due_date}}
+                </td>
+                <td>
+                  <a href="#">編集</a>
+                </td>
+              </tr>
+              @endforeach 
+            </tbody>
+          </table>
         </div>
       </div>
     </div>
-  </main>
-</body>
+  </div>
+@endsection
 
-</html>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -1,69 +1,68 @@
 @extends('layout')
 
 @section('content')
-  <div class="container">
-    <div class="row">
-      <div class="col col-md-4">
-        <nav class="panel panel-default">
-          <div class="panel-heading">フォルダ</div>
-          <div class="panel-body">
-            <a href="{{ route('folders.create') }}" class="btn btn-default btn-block">
-              フォルダを追加する
-            </a>
-          </div>
-          <div class="list-group">
-            @foreach($folders as $folder)
-            <a href="{{ route('tasks.index', ['id' => $folder->id]) }}" class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}">
-              {{ $folder->title }}
-            </a>
-
-            @endforeach
-          </div>
-        </nav>
-      </div>
-      <div class="column col-md-8">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            タスク
-          </div>
-          <div class="panel-body">
-            <div class="text-right">
-              <a href="#" class="btn btn-default btn-block">
-                タスクを追加する
-              </a>
-            </div>
-          </div>
-          <table class="table">
-            <thead>
-              <tr>
-                <th>タイトル</th>
-                <th>状態</th>
-                <th>期限</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              @foreach ($tasks as $task)
-              <tr>
-                <td>
-                  {{$task->title}}
-                </td>
-                <td>
-                  <span class="label {{$task->status_class}}">{{$task->status_label}}</span>
-                </td>
-                <td>
-                  {{$task->formatted_due_date}}
-                </td>
-                <td>
-                  <a href="#">編集</a>
-                </td>
-              </tr>
-              @endforeach 
-            </tbody>
-          </table>
+<div class="container">
+  <div class="row">
+    <div class="col col-md-4">
+      <nav class="panel panel-default">
+        <div class="panel-heading">フォルダ</div>
+        <div class="panel-body">
+          <a href="{{ route('folders.create') }}" class="btn btn-default btn-block">
+            フォルダを追加する
+          </a>
         </div>
+        <div class="list-group">
+          @foreach($folders as $folder)
+          <a href="{{ route('tasks.index', ['id' => $folder->id]) }}" class="list-group-item {{ $current_folder_id === $folder->id ? 'active' : '' }}">
+            {{ $folder->title }}
+          </a>
+
+          @endforeach
+        </div>
+      </nav>
+    </div>
+    <div class="column col-md-8">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          タスク
+        </div>
+        <div class="panel-body">
+          <div class="text-right">
+            <a href="{{ route('tasks.create', ['id' => $current_folder_id]) }}" class="btn btn-default btn-block">
+              タスクを追加する
+            </a>
+          </div>
+        </div>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>タイトル</th>
+              <th>状態</th>
+              <th>期限</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach ($tasks as $task)
+            <tr>
+              <td>
+                {{$task->title}}
+              </td>
+              <td>
+                <span class="label {{$task->status_class}}">{{$task->status_label}}</span>
+              </td>
+              <td>
+                {{$task->formatted_due_date}}
+              </td>
+              <td>
+                <a href="#">編集</a>
+              </td>
+            </tr>
+            @endforeach
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
+</div>
 @endsection
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,4 +8,4 @@ Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.
 Route::post('/folders/create', 'FolderController@create');
 // タスク作成
 Route::get('folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
-Route::post('folders?{id}/tasks/create', 'TaskController@create');
+Route::post('folders/{id}/tasks/create', 'TaskController@create');

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,5 +3,9 @@
 use App\Folder;
 
 Route::get('/folders/{id}/tasks', 'TaskController@index')->name('tasks.index');
+// フォルダ作成
 Route::get('/folders/create', 'FolderController@showCreateForm')->name('folders.create');
 Route::post('/folders/create', 'FolderController@create');
+// タスク作成
+Route::get('folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
+Route::post('folders?{id}/tasks/create', 'TaskController@create');

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Requests\CreateTask;
+use Carbon\Carbon;
+use Tests\TestCase;
+// use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class TaskTest extends TestCase
+{
+    // テストケースごとにデータベースをリフレッシュしてマイグレーションを再実行する
+    use RefreshDatabase;
+
+    /**
+     * 各テストメソッドの実行前に呼ばれる
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        // テストケース実行前にフォルダデータを作成する
+        $this->seed('FoldersTableSeeder');
+    }
+
+    /**
+     * 期限日が日付ではない場合はバリデーションエラー
+     * @test
+     */
+    public function due_date_should_be_date()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => 123, // 不正なデータ（数値）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には日付を入力してください。',
+        ]);
+    }
+
+    /**
+     * 期限日が過去日付の場合はバリデーションエラー
+     * @test
+     */
+    public function due_date_should_not_be_past()
+    {
+        $response = $this->post('/folders/1/tasks/create', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::yesterday()->format('Y/m/d'), // 不正なデータ（昨日の日付）
+        ]);
+
+        $response->assertSessionHasErrors([
+            'due_date' => '期限日 には今日以降の日付を入力してください。',
+        ]);
+    }
+}


### PR DESCRIPTION
# WHAT
ルーティング作成
タスクコントローラのshow/createメソッド作成
タスク登録ビュー作成
各種ビューファイルのリファクタリング（部分テンプレート化）
タスク作成機能ユニットテスト（バリデーションエラー検証）
# WHY
フォルダ作成機能実装と同様にルーティング、コントローラ、ビューを作成し
ビューに関しては共通部分をlayout.phpフォルダにまとめ部分テンプレート化することで可読性を向上させた。
フォルダ作成時とは異なり、リレーションを基に各タスクをフォルダに紐づけて管理できるようにコントローラ内でメソッドを定義した。
また、タスクの期限日設定に関しては作成日以前の日付以外が入力されないようにビュー側で選択できないようにした上で、バックエンド側でバリデーションを設けることで二重で予防策を講じた。
バリデーションエラーに関してはテストコードを用いて強制的に異常値が入力された際の状況を再現し、エラーメッセージが機能していることを検証した
