### PR TITLE
タスク編集機能実装

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -22,7 +22,7 @@ class TaskController extends Controller
 
         // データの入った変数はreturnで返り値を指定しviewに渡される
         // viewの引数は第一引数に読み込むテンプレートファイル名、第二引数に実際に送るデータが書かれている
-        return view ('tasks/index',[
+        return view('tasks/index', [
             'folders' => $folders,
             'current_folder_id' => $id,
             'tasks' => $tasks,
@@ -31,7 +31,7 @@ class TaskController extends Controller
 
     public function showCreateForm(int $id)
     {
-        return view('tasks/create',[
+        return view('tasks/create', [
             'folder_id' => $id
         ]);
     }
@@ -53,6 +53,15 @@ class TaskController extends Controller
 
         return redirect()->route('tasks.index', [
             'id' => $current_folder->id,
+        ]);
+    }
+
+    public function showEditForm(int $id, int $task_id)
+    {
+        $task = Task::find($task_id);
+
+        return view('task/edit', [
+            'task' => $task,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -6,6 +6,7 @@ use App\Folder;
 use App\Task;
 use Illuminate\Http\Request;
 use App\Http\Requests\CreateTask;
+use App\Http\Requests\EditTask;
 
 class TaskController extends Controller
 {
@@ -62,6 +63,23 @@ class TaskController extends Controller
 
         return view('tasks/edit', [
             'task' => $task,
+        ]);
+    }
+
+    public function edit(int $id, int $task_id, EditTask $request)
+    {
+        // 1
+        $task = Task::find($task_id);
+
+        // 2
+        $task->title = $request->title;
+        $task->status = $request->status;
+        $task->due_date = $request->due_date;
+        $task->save();
+
+        // 3
+        return redirect()->route('tasks.index', [
+            'id' => $task->folder_id,
         ]);
     }
 }

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -60,7 +60,7 @@ class TaskController extends Controller
     {
         $task = Task::find($task_id);
 
-        return view('task/edit', [
+        return view('tasks/edit', [
             'task' => $task,
         ]);
     }

--- a/app/Http/Requests/EditTask.php
+++ b/app/Http/Requests/EditTask.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Task;
+use Illuminate\Validation\Rule;
+// use Illuminate\Foundation\Http\FormRequest;
+// use TijsVerkoyen\CssToInlineStyles\Css\Rule\Rule;
+
+// cratetaskクラスとかぶる内容が多いためクラスを継承させる
+class EditTask extends CreateTask
+{
+  public function rules()
+  {
+    $rule = parent::rules();
+    $status_rule = Rule::in(array_keys(Task::STATUS));
+
+    return $rule + [
+      'status' => 'required|' . $status_rule,
+    ];
+  }
+
+  public function attributes()
+  {
+    $attributes = parent::attributes();
+
+    return $attributes + [
+      'status' => '状態',
+    ];
+  }
+
+  public function messages()
+  {
+    $messages = parent::messages();
+    $status_labels = array_map(function ($item) {
+      return $item['label'];
+    }, Task::STATUS);
+
+    $status_labels = implode('、', $status_labels);
+
+    return $messages + [
+      'status.in' => ':attribute には ' . $status_labels . ' のいずれかを指定してください。',
+    ];
+  }
+}

--- a/app/Task.php
+++ b/app/Task.php
@@ -45,6 +45,6 @@ class Task extends Model
     public function getFormattedDueDateAttribute()
     {
         return Carbon::createFromFormat('Y-m-d', $this->attributes['due_date'])
-            ->format('Y/ m/ d');
+            ->format('Y/m/d');
     }
 }

--- a/resources/views/share/flatpickr/scripts.blade.php
+++ b/resources/views/share/flatpickr/scripts.blade.php
@@ -1,0 +1,9 @@
+<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
+<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
+<script>
+  flatpickr(document.getElementById('due_date'), {
+    locale: 'ja',
+    dateFormat: "Y/m/d",
+    minDate: new Date()
+  });
+</script>

--- a/resources/views/share/flatpickr/styles.blade.php
+++ b/resources/views/share/flatpickr/styles.blade.php
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">

--- a/resources/views/tasks/create.blade.php
+++ b/resources/views/tasks/create.blade.php
@@ -1,8 +1,7 @@
 @extends('layout')
 
 @section('styles')
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-<link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+@include('share.flatpickr.styles')
 @endsection
 
 @section('content')
@@ -41,13 +40,5 @@
 @endsection
 
 @section('scripts')
-<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
-<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
-<script>
-  flatpickr(document.getElementById('due_date'), {
-    locale: 'ja',
-    dateFormat: "Y/m/d",
-    minDate: new Date()
-  });
-</script>
+@include('share.flatpickr.scripts')
 @endsection

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,8 +1,7 @@
 @extends('layout')
 
 @section('styles')
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-<link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+@include('share.flatpickr.styles')
 @endsection
 
 @section('content')
@@ -51,13 +50,5 @@
 @endsection
 
 @section('scripts')
-<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
-<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
-<script>
-  flatpickr(document.getElementById('due_date'), {
-    locale: 'ja',
-    dateFormat: "Y/m/d",
-    minDate: new Date()
-  });
-</script>
+@include('share.flatpickr.scripts')
 @endsection

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -22,7 +22,7 @@
             @csrf
             <div class="form-group">
               <label for="title">タイトル</label>
-              <input type="text" class="form-control" name="title" id="title" value="{{ old('title') ?? $task->title }}" />
+              <input type="text" class="form-control" name="title" id="title" value="{{ old('title', $task->title) }}" />
             </div>
             <div class="form-group">
               <label for="status">状態</label>
@@ -36,7 +36,7 @@
             </div>
             <div class="form-group">
               <label for="due_date">期限</label>
-              <input type="text" class="form-control" name="due_date" id="due_date" value="{{ old('due_date') ?? $task->formatted_due_date }}" />
+              <input type="text" class="form-control" name="due_date" id="due_date" value="{{ old('due_date', $task->formatted_due_date) }}" />
             </div>
             <div class="text-right">
               <button type="submit" class="btn btn-primary">送信</button>

--- a/resources/views/tasks/edit.blade.php
+++ b/resources/views/tasks/edit.blade.php
@@ -1,0 +1,63 @@
+@extends('layout')
+
+@section('styles')
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+<link rel="stylesheet" href="https://npmcdn.com/flatpickr/dist/themes/material_blue.css">
+@endsection
+
+@section('content')
+<div class="container">
+  <div class="row">
+    <div class="col col-md-offset-3 col-md-6">
+      <nav class="panel panel-default">
+        <div class="panel-heading">タスクを編集する</div>
+        <div class="panel-body">
+          @if($errors->any())
+          <div class="alert alert-danger">
+            @foreach($errors->all() as $message)
+            <p>{{ $message }}</p>
+            @endforeach
+          </div>
+          @endif
+          <form action="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}" method="POST">
+            @csrf
+            <div class="form-group">
+              <label for="title">タイトル</label>
+              <input type="text" class="form-control" name="title" id="title" value="{{ old('title') ?? $task->title }}" />
+            </div>
+            <div class="form-group">
+              <label for="status">状態</label>
+              <select name="status" id="status" class="form-control">
+                @foreach(\App\Task::STATUS as $key => $val)
+                <option value="{{ $key }}" {{ $key == old('status', $task->status) ? 'selected' : '' }}>
+                  {{ $val['label'] }}
+                </option>
+                @endforeach
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="due_date">期限</label>
+              <input type="text" class="form-control" name="due_date" id="due_date" value="{{ old('due_date') ?? $task->formatted_due_date }}" />
+            </div>
+            <div class="text-right">
+              <button type="submit" class="btn btn-primary">送信</button>
+            </div>
+          </form>
+        </div>
+      </nav>
+    </div>
+  </div>
+</div>
+@endsection
+
+@section('scripts')
+<script src="https://npmcdn.com/flatpickr/dist/flatpickr.min.js"></script>
+<script src="https://npmcdn.com/flatpickr/dist/l10n/ja.js"></script>
+<script>
+  flatpickr(document.getElementById('due_date'), {
+    locale: 'ja',
+    dateFormat: "Y/m/d",
+    minDate: new Date()
+  });
+</script>
+@endsection

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -55,7 +55,7 @@
                 {{$task->formatted_due_date}}
               </td>
               <td>
-                <a href="#">編集</a>
+                <a href="{{ route('tasks.edit', ['id' => $task->folder_id, 'task_id' => $task->id]) }}">編集</a>
               </td>
             </tr>
             @endforeach

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,3 +9,6 @@ Route::post('/folders/create', 'FolderController@create');
 // タスク作成
 Route::get('folders/{id}/tasks/create', 'TaskController@showCreateForm')->name('tasks.create');
 Route::post('folders/{id}/tasks/create', 'TaskController@create');
+// タスク編集
+Route::get('folders/{id}/tasks/{task_id}/edit', 'TaskController@showEditForm')->name('tasks.edit');
+Route::post('folders/{id}/tasks/{task_id}/edit', 'TaskController@edit');

--- a/tests/Feature/TaskTest.php
+++ b/tests/Feature/TaskTest.php
@@ -55,4 +55,23 @@ class TaskTest extends TestCase
             'due_date' => '期限日 には今日以降の日付を入力してください。',
         ]);
     }
+
+    /**
+     * 状態が定義された値ではない場合はバリデーションエラー
+     * @test
+     */
+    public function status_should_be_within_defined_numbers()
+    {
+        $this->seed('TasksTableSeeder');
+
+        $response = $this->post('/folders/1/tasks/1/edit', [
+            'title' => 'Sample task',
+            'due_date' => Carbon::today()->format('Y/m/d'),
+            'status' => 999,
+        ]);
+
+        $response->assertSessionHasErrors([
+            'status' => '状態 には 未着手、着手中、完了 のいずれかを指定してください。',
+        ]);
+    }
 }


### PR DESCRIPTION
# WHAT
ルーティング作成
タスクコントローラのeditアクションshow/createメソッド作成
タスク編集ビュー作成
スクリプト部分のリファクタリング（部分テンプレート化）
タスク編集機能ユニットテスト（バリデーションエラー検証）

# WHY
タスク編集機能のためコントローラ内で元の情報を取り出し
formに初期値として挿入した上で任意に変更できるように実装した。
データフォーマットに不要なスペースが含まれていたために、
保存される際の値とビューに返される値が異なっていたことが原因で
変更機能が働くたびに日付を入れ直す必要があったためフォーマットを修正した
